### PR TITLE
Fix: Removed modalBottomSheet save handling

### DIFF
--- a/lib/visuals/screens/tasks/index.dart
+++ b/lib/visuals/screens/tasks/index.dart
@@ -449,7 +449,6 @@ class _TasksPageState extends State<TasksPage> {
                                           : null,
                                       selectedDate,
                                     );
-                                    Navigator.pop(context);
                                   } else {
                                     _addTask(
                                       _taskTitleController.text,
@@ -458,10 +457,8 @@ class _TasksPageState extends State<TasksPage> {
                                           : null,
                                       selectedDate,
                                     );
-                                    _taskTitleController.clear();
-                                    _taskBodyController.clear();
-                                    Focus.of(context).unfocus();
                                   }
+                                  Navigator.pop(context);
                                 }
                               },
                               child: const Text("Save"),


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail.   -->

### Related Issue

<!-- If applicable, mention the issue this pull request resolves (e.g., Fixes #123).   -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Key Changes

1. **bottomSheet:**

- The Focus.unfocus isn't working as intended hence removed it


## Checklist

- [x] I have tested the changes locally.
- [ ] I have updated documentation (if necessary).
- [x] I have followed the project’s contribution guidelines.

## Additional Notes

<!-- Add any additional information about the pull request.   -->
